### PR TITLE
Linking wandb logs to our assigned project

### DIFF
--- a/experiments/distributed/segmentation/main_fedseg.py
+++ b/experiments/distributed/segmentation/main_fedseg.py
@@ -228,8 +228,7 @@ if __name__ == "__main__":
     # initialize the wandb machine learning experimental tracking platform (https://www.wandb.com/).
     if process_id == 0:
         wandb.init(
-            # project="federated_nas",
-            project = "fedml",
+            project = "fedcv-segmentation",
             name = args.process_name + str(args.partition_method) + "r" + str(args.comm_round) + "-e" + str(
                 args.epochs) + "-lr" + str(
                 args.lr),


### PR DESCRIPTION
We are logging in the wandb fedml project instead of assigned fedcv-segmentation project.
Please review @sadarshannaiynar @keerti-1997 